### PR TITLE
Fixed: Can not start nginx after install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,7 +246,7 @@ http {
     add_header X-Clacks-Overhead "GNU Terry Pratchett";
 
     location /tr069 {
-      proxy_set_header        X-Real-IP       $remote_addr;
+      proxy_set_header        X-Real-IP       \$remote_addr;
       proxy_pass http://localhost:8085/tr069;
     }
     location /web/ {


### PR DESCRIPTION
Fix error: `nginx: [emerg] invalid number of arguments in "proxy_set_header" directive in /etc/nginx/nginx.conf:14` when start nginx.