### PR TITLE
rip out all db operations from session cache (part 2 of Restructure All The Things)

### DIFF
--- a/tr069/src/main/java/com/github/freeacs/base/JobLogic.java
+++ b/tr069/src/main/java/com/github/freeacs/base/JobLogic.java
@@ -1,15 +1,9 @@
 package com.github.freeacs.base;
 
 import com.github.freeacs.base.db.DBAccess;
-import com.github.freeacs.dbi.Job;
+import com.github.freeacs.dbi.*;
 import com.github.freeacs.dbi.JobFlag.JobServiceWindow;
 import com.github.freeacs.dbi.JobFlag.JobType;
-import com.github.freeacs.dbi.JobParameter;
-import com.github.freeacs.dbi.JobStatus;
-import com.github.freeacs.dbi.Jobs;
-import com.github.freeacs.dbi.Unit;
-import com.github.freeacs.dbi.UnitJobStatus;
-import com.github.freeacs.dbi.UnitParameter;
 import com.github.freeacs.dbi.util.ProvisioningMode;
 import com.github.freeacs.dbi.util.SystemParameters;
 import java.util.HashMap;
@@ -24,7 +18,7 @@ import java.util.Map.Entry;
  * @author morten
  */
 public class JobLogic {
-  public static boolean checkJobOK(SessionDataI sessionData, boolean isDiscoveryMode) {
+  public static boolean checkJobOK(SessionDataI sessionData, ACS acs, boolean isDiscoveryMode) {
     try {
       String jobId = sessionData.getAcsParameters().getValue(SystemParameters.JOB_CURRENT);
       if (jobId != null && !jobId.trim().isEmpty()) {
@@ -35,7 +29,7 @@ public class JobLogic {
               JobLogic.class, "Current job " + jobId + " does no longer exist, cannot be verified");
           return false;
         }
-        UnitJob uj = new UnitJob(sessionData, job, false);
+        UnitJob uj = new UnitJob(sessionData, acs, job, false);
         if (!JobStatus.STARTED.equals(job.getStatus())) {
           Log.warn(JobLogic.class, "Current job is not STARTED, UnitJob must be STOPPED");
           uj.stop(UnitJobStatus.STOPPED, isDiscoveryMode);
@@ -96,15 +90,15 @@ public class JobLogic {
     }
   }
 
-  public static UnitJob checkNewJob(SessionDataI sessionData, int downloadLimit) {
+  public static UnitJob checkNewJob(SessionDataI sessionData, ACS acs, int downloadLimit) {
     if (sessionData.getUnit().getProvisioningMode() == ProvisioningMode.REGULAR) {
       Job job = getJob(sessionData, downloadLimit);
       if (job != null) {
         UnitJob uj = null;
         if (job.getFlags().getType() == JobType.SHELL) {
-          uj = new UnitJob(sessionData, job, true);
+          uj = new UnitJob(sessionData, acs, job, true);
         } else {
-          uj = new UnitJob(sessionData, job, false);
+          uj = new UnitJob(sessionData, acs, job, false);
         }
         uj.start();
         sessionData.setJob(job);

--- a/tr069/src/main/java/com/github/freeacs/base/SessionDataI.java
+++ b/tr069/src/main/java/com/github/freeacs/base/SessionDataI.java
@@ -32,8 +32,6 @@ public interface SessionDataI {
 
   void setUnitId(String unitId);
 
-  DBAccessSession getDbAccessSession();
-
   Job getJob();
 
   void setJob(Job job);
@@ -47,8 +45,6 @@ public interface SessionDataI {
   void setSoftwareVersion(String softwareVersion);
 
   Map<String, ParameterValueStruct> getFromDB();
-
-  void updateParametersFromDB(String unitId, boolean isDiscoveryMode) throws SQLException;
 
   void setFromDB(Map<String, ParameterValueStruct> fromDB);
 

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
@@ -1,14 +1,18 @@
 package com.github.freeacs.base.db;
 
+import com.github.freeacs.base.ACSParameters;
 import com.github.freeacs.base.Log;
+import com.github.freeacs.base.NoDataAvailableException;
 import com.github.freeacs.base.SessionDataI;
-import com.github.freeacs.dbi.ACS;
-import com.github.freeacs.dbi.ACSUnit;
-import com.github.freeacs.dbi.Unit;
-import com.github.freeacs.dbi.Unittype;
-import com.github.freeacs.dbi.UnittypeParameter;
+import com.github.freeacs.dbi.*;
+import com.github.freeacs.tr069.SessionData;
+import com.github.freeacs.tr069.xml.ParameterValueStruct;
+
 import java.sql.SQLException;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class DBAccessSession {
   private final ACS acs;
@@ -17,20 +21,107 @@ public class DBAccessSession {
     this.acs = acs;
   }
 
-  public void writeUnittypeParameters(SessionDataI sessionData, List<UnittypeParameter> utpList)
-      throws SQLException {
-    String method = "writeUnittypeParameters";
+  public void updateParametersFromDB(SessionData sessionData, boolean isDiscoveryMode) throws SQLException {
+    if (sessionData.getFromDB() != null) {
+      return;
+    }
+
+    Log.debug(SessionData.class, "Will load unit data");
+    addUnitDataToSession(sessionData);
+
+    if (sessionData.getFromDB().isEmpty()) {
+      if (isDiscoveryMode) {
+        Log.debug(
+                SessionData.class,
+                "No unit data found & discovery mode true -> first-connect = true, allow to continue");
+        sessionData.setFirstConnect(true);
+      } else {
+        throw new NoDataAvailableException();
+      }
+    }
+
+    if (!sessionData.getFromDB().isEmpty()) {
+      if (sessionData.getAcsParameters() == null) {
+        sessionData.setAcsParameters(new ACSParameters());
+      }
+      Iterator<String> i = sessionData.getFromDB().keySet().iterator();
+      int systemParamCounter = 0;
+      while (i.hasNext()) {
+        String utpName = i.next();
+        UnittypeParameter utp = sessionData.getUnittype().getUnittypeParameters().getByName(utpName);
+        if (utp != null && utp.getFlag().isSystem()) {
+          systemParamCounter++;
+          sessionData.getAcsParameters().putPvs(utpName, sessionData.getFromDB().get(utpName));
+          i.remove();
+        }
+      }
+      Log.debug(
+              SessionData.class,
+              "Removed "
+                      + systemParamCounter
+                      + " system parameter from param-list, now contains "
+                      + sessionData.getFromDB().size()
+                      + " params");
+    }
+  }
+
+  private void addUnitDataToSession(SessionData sessionData) throws SQLException {
+    Unit unit = readUnit(sessionData.getUnitId());
+    Map<String, ParameterValueStruct> valueMap = new TreeMap<>();
+    if (unit != null) {
+      sessionData.setUnit(unit);
+      sessionData.setUnittype(unit.getUnittype());
+      sessionData.setProfile(unit.getProfile());
+      ProfileParameter[] pparams = unit.getProfile().getProfileParameters().getProfileParameters();
+      for (ProfileParameter pp : pparams) {
+        String utpName = pp.getUnittypeParameter().getName();
+        valueMap.put(utpName, new ParameterValueStruct(utpName, pp.getValue()));
+      }
+      int overrideCounter = 0;
+      for (Map.Entry<String, UnitParameter> entry : unit.getUnitParameters().entrySet()) {
+        if (!entry.getValue().getParameter().valueWasNull()) {
+          String utpName = entry.getKey();
+          String value = entry.getValue().getValue();
+          ParameterValueStruct pvs = new ParameterValueStruct(utpName, value);
+          if (valueMap.containsKey(utpName)) {
+            overrideCounter++;
+          }
+          valueMap.put(utpName, pvs);
+        } else {
+          System.out.println(entry.getKey() + " is probably a session-parameter");
+        }
+      }
+      int alwaysCounter = 0;
+      for (Map.Entry<Integer, UnittypeParameter> entry :
+              unit.getUnittype().getUnittypeParameters().getAlwaysMap().entrySet()) {
+        String utpName = entry.getValue().getName();
+        if (!valueMap.containsKey(utpName)) {
+          alwaysCounter++;
+          valueMap.put(utpName, new ParameterValueStruct(utpName, ""));
+        }
+      }
+      String msg = "Found unit in database - in total " + valueMap.size() + " params ";
+      msg += "(" + unit.getUnitParameters().size() + " unit params, ";
+      msg += pparams.length + " profile params (" + overrideCounter + " overridden), ";
+      msg += alwaysCounter + " always read params added)";
+      Log.debug(SessionData.class, msg);
+    } else {
+      Log.warn(SessionData.class, "Did not find unit in unit-table, nothing exists on this unit");
+    }
+    sessionData.setFromDB(valueMap);
+  }
+
+  public void writeUnittypeParameters(SessionDataI sessionData, List<UnittypeParameter> utpList) throws SQLException {
     try {
       Unittype ut = sessionData.getUnittype();
       ut.getUnittypeParameters().addOrChangeUnittypeParameters(utpList, acs);
       Log.debug(DBAccessSession.class, "Have written " + utpList.size() + " unittype parameters");
     } catch (Throwable t) {
-      DBAccess.handleError(method, t);
+      DBAccess.handleError("writeUnittypeParameters", t);
     }
   }
 
   public Unit readUnit(String unitId) throws SQLException {
-    String method = "readUnit";
     Unit unit;
     try {
       ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
@@ -47,9 +138,9 @@ public class DBAccessSession {
       }
       return unit;
     } catch (Throwable t) {
-      DBAccess.handleError(method, t);
+      DBAccess.handleError("readUnit", t);
+      return null;
     }
-    return null; // unreachable code - compiler doesn't detect it!
   }
 
   public ACS getAcs() {

--- a/tr069/src/main/java/com/github/freeacs/base/http/BasicAuthenticator.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/BasicAuthenticator.java
@@ -3,6 +3,7 @@ package com.github.freeacs.base.http;
 import com.github.freeacs.base.BaseCache;
 import com.github.freeacs.base.Log;
 import com.github.freeacs.base.NoDataAvailableException;
+import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.util.SystemParameters;
 import com.github.freeacs.http.HTTPRequestResponseData;
 import com.github.freeacs.tr069.SessionData;
@@ -76,8 +77,7 @@ public class BasicAuthenticator {
     try {
       SessionData sessionData = reqRes.getSessionData();
       sessionData.setUnitId(unitId);
-      sessionData.updateParametersFromDB(
-          unitId, isDiscoveryMode); // Unit is now stored in sessionData
+      new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs()).updateParametersFromDB(sessionData, isDiscoveryMode); // Unit is now stored in sessionData
       String secret = null;
       if (sessionData.isFirstConnect() && isDiscoveryMode) {
         for (String blocked : discoveryBlocked) {

--- a/tr069/src/main/java/com/github/freeacs/base/http/DigestAuthenticator.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/DigestAuthenticator.java
@@ -3,6 +3,7 @@ package com.github.freeacs.base.http;
 import com.github.freeacs.base.BaseCache;
 import com.github.freeacs.base.Log;
 import com.github.freeacs.base.NoDataAvailableException;
+import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.util.SystemParameters;
 import com.github.freeacs.http.HTTPRequestResponseData;
 import com.github.freeacs.tr069.SessionData;
@@ -172,7 +173,7 @@ public class DigestAuthenticator {
     try {
       SessionData sessionData = reqRes.getSessionData();
       sessionData.setUnitId(unitId);
-      sessionData.updateParametersFromDB(unitId, isDiscoveryMode);
+      new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs()).updateParametersFromDB(sessionData, isDiscoveryMode);
       BaseCache.putSessionData(unitId, sessionData);
       String secret = sessionData.getAcsParameters().getValue(SystemParameters.SECRET);
       if (secret != null

--- a/tr069/src/main/java/com/github/freeacs/http/HTTPRequestResponseData.java
+++ b/tr069/src/main/java/com/github/freeacs/http/HTTPRequestResponseData.java
@@ -29,8 +29,7 @@ public class HTTPRequestResponseData {
 
   private SessionData sessionData;
 
-  protected HTTPRequestResponseData(HttpServletRequest rawRequest, HttpServletResponse rawResponse, DBAccess dbAccess)
-      throws SQLException {
+  protected HTTPRequestResponseData(HttpServletRequest rawRequest, HttpServletResponse rawResponse, DBAccess dbAccess) {
     this.rawRequest = rawRequest;
     this.rawResponse = rawResponse;
     this.requestData = new HTTPRequestData();
@@ -57,7 +56,7 @@ public class HTTPRequestResponseData {
               + session.getLastAccessedTime()
               + ", mxInactiveInterval:"
               + session.getMaxInactiveInterval());
-      sessionData = new SessionData(sessionId, dbAccess.getDBI().getAcs());
+      sessionData = new SessionData(sessionId);
       BaseCache.putSessionData(sessionId, sessionData);
     }
     if (sessionData.getStartupTmsForSession() == null) {

--- a/tr069/src/main/java/com/github/freeacs/tr069/Provisioning.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/Provisioning.java
@@ -231,7 +231,7 @@ public class Provisioning extends AbstractHttpDataWrapper {
     try {
       Unit unit = reqRes.getSessionData().getUnit();
       if (unit != null) {
-        ACS acs = reqRes.getSessionData().getDbAccessSession().getAcs();
+        ACS acs = reqRes.getDbAccess().getDBI().getAcs();
         ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
         acsUnit.addOrChangeQueuedUnitParameters(unit);
       }

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/EmptyDecisionStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/EmptyDecisionStrategy.java
@@ -126,11 +126,9 @@ public class EmptyDecisionStrategy implements DecisionStrategy {
             }
         }
         sessionData.setToDB(toDB);
-        DBAccessSessionTR069.writeUnitParams(
-                sessionData); // queue-parameters - will be written at end-of-session
-        if (!queue) { // execute changes immediately - since otherwise these parameters will be lost (in
-            // the event of GPNRes.process())
-            ACS acs = reqRes.getSessionData().getDbAccessSession().getAcs();
+        DBAccessSessionTR069.writeUnitParams(sessionData); // queue-parameters - will be written at end-of-session
+        if (!queue) { // execute changes immediately - since otherwise these parameters will be lost (in the event of GPNRes.process())
+            ACS acs = reqRes.getDbAccess().getDBI().getAcs();
             ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
             acsUnit.addOrChangeQueuedUnitParameters(sessionData.getUnit());
         }

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/SetParameterValuesDecisionStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/SetParameterValuesDecisionStrategy.java
@@ -26,7 +26,7 @@ public class SetParameterValuesDecisionStrategy implements DecisionStrategy {
             Log.debug(
                     SetParameterValuesDecisionStrategy.class,
                     "UnitJob is COMPLETED without verification stage, since CPE does not support ParameterKey");
-            UnitJob uj = new UnitJob(sessionData, sessionData.getJob(), false);
+            UnitJob uj = new UnitJob(sessionData, reqRes.getDbAccess().getDBI().getAcs(), sessionData.getJob(), false);
             uj.stop(UnitJobStatus.COMPLETED_OK, properties.isDiscoveryMode());
         }
         reqRes.getResponseData().setMethod(ProvisioningMethod.Empty.name());

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/request/GetParameterNamesProcessStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/request/GetParameterNamesProcessStrategy.java
@@ -1,6 +1,7 @@
 package com.github.freeacs.tr069.methods.request;
 
 import com.github.freeacs.base.Log;
+import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.Unittype;
 import com.github.freeacs.dbi.UnittypeParameter;
 import com.github.freeacs.dbi.UnittypeParameterFlag;
@@ -78,13 +79,14 @@ public class GetParameterNamesProcessStrategy implements RequestProcessStrategy 
                                     + " was found more than once in the GPNRes");
                 }
             }
-            sessionData.getDbAccessSession().writeUnittypeParameters(sessionData, utpList);
+            DBAccessSession dbAccessSession = new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs());
+            dbAccessSession.writeUnittypeParameters(sessionData, utpList);
             Log.debug(
                     GetParameterNamesProcessStrategy.class,
                     "Unittype parameters (" + pisList.size() + ") is written to DB, will now reload unit");
             sessionData.setFromDB(null);
             sessionData.setAcsParameters(null);
-            sessionData.updateParametersFromDB(sessionData.getUnitId(), properties.isDiscoveryMode());
+            dbAccessSession.updateParametersFromDB(sessionData, properties.isDiscoveryMode());
         } catch (Throwable t) {
             throw new TR069Exception("Processing GPNRes failed", TR069ExceptionShortMessage.MISC, t);
         }

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/request/SetParameterValuesRequestProcessStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/request/SetParameterValuesRequestProcessStrategy.java
@@ -1,6 +1,7 @@
 package com.github.freeacs.tr069.methods.request;
 
 import com.github.freeacs.base.Log;
+import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.SyslogConstants;
 import com.github.freeacs.dbi.util.SyslogClient;
 import com.github.freeacs.http.HTTPRequestResponseData;
@@ -25,9 +26,7 @@ public class SetParameterValuesRequestProcessStrategy implements RequestProcessS
         ParameterList paramList = sessionData.getToCPE();
         for (ParameterValueStruct pvs : paramList.getParameterValueList()) {
             Log.notice(SetParameterValuesRequestProcessStrategy.class, "\t" + pvs.getName() + " : " + pvs.getValue());
-            String user =
-                    sessionData
-                            .getDbAccessSession()
+            String user = new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs())
                             .getAcs()
                             .getSyslog()
                             .getIdentity()


### PR DESCRIPTION
The session cache object aka SessionData should be a data only object, a simple POJO. I have now ripped out every db operation from session cache. the ACS object is now retrieved somewhere else and logic is moved into DBAccessSession.