### PR TITLE
make DBI a singleton object (part 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ target
 /scripts/conf
 /project/target
 /project/project
-/db
+./db
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ target
 /scripts/conf
 /project/target
 /project/project
-./db
 .DS_Store

--- a/common/src/main/java/com/github/freeacs/common/spark/SparkApp.java
+++ b/common/src/main/java/com/github/freeacs/common/spark/SparkApp.java
@@ -17,4 +17,14 @@ public abstract class SparkApp {
         Spark.port(config.getInt("server.port"));
         datasource = HikariDataSourceHelper.dataSource(config.getConfig("main"));
     }
+
+    protected int getIntOrMinusOne(String s) {
+        return getIntOrMinusOne(config, s);
+    }
+
+    protected int getIntOrMinusOne(Config config, String s) {
+        return config.hasPath(s) ? config.getInt(s) : -1;
+    }
+
+
 }

--- a/tr069/src/main/java/com/github/freeacs/base/JobLogic.java
+++ b/tr069/src/main/java/com/github/freeacs/base/JobLogic.java
@@ -1,6 +1,5 @@
 package com.github.freeacs.base;
 
-import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.dbi.*;
 import com.github.freeacs.dbi.JobFlag.JobServiceWindow;
 import com.github.freeacs.dbi.JobFlag.JobType;
@@ -23,7 +22,7 @@ public class JobLogic {
       String jobId = sessionData.getAcsParameters().getValue(SystemParameters.JOB_CURRENT);
       if (jobId != null && !jobId.trim().isEmpty()) {
         Log.debug(JobLogic.class, "Verification stage entered for job " + jobId);
-        Job job = DBAccess.getJob(sessionData, jobId);
+        Job job = sessionData.getUnittype().getJobs().getById(Integer.valueOf(jobId));
         if (job == null) {
           Log.warn(
               JobLogic.class, "Current job " + jobId + " does no longer exist, cannot be verified");

--- a/tr069/src/main/java/com/github/freeacs/base/ResetUtil.java
+++ b/tr069/src/main/java/com/github/freeacs/base/ResetUtil.java
@@ -1,6 +1,5 @@
 package com.github.freeacs.base;
 
-import com.github.freeacs.base.db.DBAccessStatic;
 import com.github.freeacs.dbi.UnitParameter;
 import com.github.freeacs.dbi.Unittype;
 import com.github.freeacs.dbi.UnittypeParameter;
@@ -8,29 +7,24 @@ import com.github.freeacs.dbi.util.SystemParameters;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Util {
+public class ResetUtil {
   public static void resetReboot(SessionDataI sessionData) {
-    Log.debug(Util.class, "The reboot parameter is reset to 0 and the reboot will be executed");
+    Log.debug(ResetUtil.class, "The reboot parameter is reset to 0 and the reboot will be executed");
     Unittype unittype = sessionData.getUnittype();
     UnittypeParameter utp = unittype.getUnittypeParameters().getByName(SystemParameters.RESTART);
     List<UnitParameter> unitParameters = new ArrayList<>();
-    UnitParameter up =
-        new UnitParameter(utp, sessionData.getUnitId(), "0", sessionData.getProfile());
+    UnitParameter up = new UnitParameter(utp, sessionData.getUnitId(), "0", sessionData.getProfile());
     unitParameters.add(up);
-    DBAccessStatic.queueUnitParameters(
-        sessionData.getUnit(), unitParameters, sessionData.getProfile());
+    unitParameters.forEach(sessionData.getUnit()::toWriteQueue);
   }
 
   public static void resetReset(SessionDataI sessionData) {
-    Log.debug(
-        Util.class, "The reset parameter is reset to 0 and the factory reset will be executed");
+    Log.debug(ResetUtil.class, "The reset parameter is reset to 0 and the factory reset will be executed");
     Unittype unittype = sessionData.getUnittype();
     UnittypeParameter utp = unittype.getUnittypeParameters().getByName(SystemParameters.RESET);
     List<UnitParameter> unitParameters = new ArrayList<>();
-    UnitParameter up =
-        new UnitParameter(utp, sessionData.getUnitId(), "0", sessionData.getProfile());
+    UnitParameter up = new UnitParameter(utp, sessionData.getUnitId(), "0", sessionData.getProfile());
     unitParameters.add(up);
-    DBAccessStatic.queueUnitParameters(
-        sessionData.getUnit(), unitParameters, sessionData.getProfile());
+    unitParameters.forEach(sessionData.getUnit()::toWriteQueue);
   }
 }

--- a/tr069/src/main/java/com/github/freeacs/base/UnitJob.java
+++ b/tr069/src/main/java/com/github/freeacs/base/UnitJob.java
@@ -92,7 +92,7 @@ public class UnitJob {
         continue;
       }
       JobHistoryEntry jhEntry = new JobHistoryEntry(entry);
-        Job entryJob = sessionData.getUnittype().getJobs().getById(Integer.valueOf(String.valueOf(jhEntry.getJobId())));
+      Job entryJob = sessionData.getUnittype().getJobs().getById(Integer.valueOf(String.valueOf(jhEntry.getJobId())));
       if (entryJob != null) {
         if (Objects.equals(entryJob.getId(), jobId)) { // inc repeated-counter
           jh2 += jhEntry.incEntry(tms) + ",";

--- a/tr069/src/main/java/com/github/freeacs/base/UnitJob.java
+++ b/tr069/src/main/java/com/github/freeacs/base/UnitJob.java
@@ -270,7 +270,7 @@ public class UnitJob {
                 + jobId
                 + ", will stop unit job with unit job status set to "
                 + unitJobStatus);
-          job = sessionData.getUnittype().getJobs().getById(Integer.valueOf(jobIdStr));
+        job = sessionData.getUnittype().getJobs().getById(Integer.valueOf(jobIdStr));
         if (job == null && !unitJobStatus.equals(UnitJobStatus.CONFIRMED_FAILED)) {
           Log.warn(
               UnitJob.class,

--- a/tr069/src/main/java/com/github/freeacs/base/UnitJob.java
+++ b/tr069/src/main/java/com/github/freeacs/base/UnitJob.java
@@ -1,6 +1,5 @@
 package com.github.freeacs.base;
 
-import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.base.db.DBAccessStatic;
 import com.github.freeacs.dbi.ACS;
@@ -93,7 +92,7 @@ public class UnitJob {
         continue;
       }
       JobHistoryEntry jhEntry = new JobHistoryEntry(entry);
-      Job entryJob = DBAccess.getJob(sessionData, String.valueOf(jhEntry.getJobId()));
+        Job entryJob = sessionData.getUnittype().getJobs().getById(Integer.valueOf(String.valueOf(jhEntry.getJobId())));
       if (entryJob != null) {
         if (Objects.equals(entryJob.getId(), jobId)) { // inc repeated-counter
           jh2 += jhEntry.incEntry(tms) + ",";
@@ -120,12 +119,10 @@ public class UnitJob {
       try {
         String unitId = sessionData.getUnitId();
         if (!serverSideJob) {
-          UnitParameter jobUp =
-              makeUnitParameter(SystemParameters.JOB_CURRENT, String.valueOf(job.getId()));
+          UnitParameter jobUp = makeUnitParameter(SystemParameters.JOB_CURRENT, String.valueOf(job.getId()));
           List<UnitParameter> upList = new ArrayList<>();
           upList.add(jobUp);
-          DBAccessStatic.queueUnitParameters(
-              sessionData.getUnit(), upList, sessionData.getProfile());
+          upList.forEach(sessionData.getUnit()::toWriteQueue);
         }
         DBAccessStatic.startUnitJob(
             unitId, job.getId(), acs.getDataSource());
@@ -171,7 +168,7 @@ public class UnitJob {
         sessionData.getPIIDecision().setCurrentJobStatus(unitJobStatus);
         // Write directly to database, no queuing, since the all data are flushed in next step (most
         // likely)
-        ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
         acsUnit.addOrChangeUnitParameters(upList, sessionData.getProfile());
         if (!serverSideJob) {
           sessionData.setFromDB(null);
@@ -273,7 +270,7 @@ public class UnitJob {
                 + jobId
                 + ", will stop unit job with unit job status set to "
                 + unitJobStatus);
-        job = DBAccess.getJob(sessionData, jobIdStr);
+          job = sessionData.getUnittype().getJobs().getById(Integer.valueOf(jobIdStr));
         if (job == null && !unitJobStatus.equals(UnitJobStatus.CONFIRMED_FAILED)) {
           Log.warn(
               UnitJob.class,

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessErrorHandler.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessErrorHandler.java
@@ -1,0 +1,15 @@
+package com.github.freeacs.base.db;
+
+import com.github.freeacs.base.Log;
+
+import java.sql.SQLException;
+
+abstract class DBAccessErrorHandler {
+    static void handleError(String method, Throwable t) throws SQLException {
+        Log.error(DBAccess.class, method + " failed", t);
+        if (t instanceof SQLException) {
+            throw (SQLException) t;
+        }
+        throw (RuntimeException) t;
+    }
+}

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
@@ -117,14 +117,14 @@ public class DBAccessSession {
       ut.getUnittypeParameters().addOrChangeUnittypeParameters(utpList, acs);
       Log.debug(DBAccessSession.class, "Have written " + utpList.size() + " unittype parameters");
     } catch (Throwable t) {
-      DBAccess.handleError("writeUnittypeParameters", t);
+      DBAccessErrorHandler.handleError("writeUnittypeParameters", t);
     }
   }
 
   public Unit readUnit(String unitId) throws SQLException {
     Unit unit;
     try {
-      ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
       unit = acsUnit.getUnitById(unitId);
       if (unit != null) {
         Log.debug(
@@ -138,7 +138,7 @@ public class DBAccessSession {
       }
       return unit;
     } catch (Throwable t) {
-      DBAccess.handleError("readUnit", t);
+      DBAccessErrorHandler.handleError("readUnit", t);
       return null;
     }
   }

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
@@ -121,7 +121,7 @@ public class DBAccessSession {
     }
   }
 
-  public Unit readUnit(String unitId) throws SQLException {
+  Unit readUnit(String unitId) throws SQLException {
     Unit unit;
     try {
         ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSession.java
@@ -124,7 +124,7 @@ public class DBAccessSession {
   Unit readUnit(String unitId) throws SQLException {
     Unit unit;
     try {
-        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
+      ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
       unit = acsUnit.getUnitById(unitId);
       if (unit != null) {
         Log.debug(

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSessionTR069.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSessionTR069.java
@@ -61,7 +61,7 @@ public class DBAccessSessionTR069 {
       sessionData.setUnittype(ut);
       sessionData.setProfile(pr);
 
-        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
+      ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
       List<String> unitIds = new ArrayList<>();
       unitIds.add(unitId);
       acsUnit.addUnits(unitIds, pr);
@@ -112,7 +112,7 @@ public class DBAccessSessionTR069 {
         }
       }
       if (!unitSessionParameters.isEmpty()) {
-          ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
+        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
         acsUnit.addOrChangeSessionUnitParameters(unitSessionParameters, profile);
       }
     } catch (SQLException sqle) {
@@ -130,12 +130,9 @@ public class DBAccessSessionTR069 {
     for (ParameterValueStruct pvs : parameterValuesToDB) {
       UnittypeParameter utp = unittype.getUnittypeParameters().getByName(pvs.getName());
       if (utp != null) {
-        unitParameters.add(
-            new UnitParameter(utp, sessionData.getUnitId(), pvs.getValue(), profile));
+        unitParameters.add(new UnitParameter(utp, sessionData.getUnitId(), pvs.getValue(), profile));
       } else {
-        Log.warn(
-            DBAccessSession.class,
-            "\t" + pvs.getName() + " : does not exist, cannot write value " + pvs.getValue());
+        Log.warn(DBAccessSession.class,"\t" + pvs.getName() + " : does not exist, cannot write value " + pvs.getValue());
       }
     }
     unitParameters.forEach(unit::toWriteQueue);

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSessionTR069.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSessionTR069.java
@@ -83,7 +83,7 @@ public class DBAccessSessionTR069 {
     }
   }
 
-  protected static String getUnittypeName(String unitId) {
+  static String getUnittypeName(String unitId) {
     return "OUI-" + unitId.substring(0, Math.min(unitId.length(), 6));
   }
 

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSessionTR069.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessSessionTR069.java
@@ -61,7 +61,7 @@ public class DBAccessSessionTR069 {
       sessionData.setUnittype(ut);
       sessionData.setProfile(pr);
 
-      ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
       List<String> unitIds = new ArrayList<>();
       unitIds.add(unitId);
       acsUnit.addUnits(unitIds, pr);
@@ -112,7 +112,7 @@ public class DBAccessSessionTR069 {
         }
       }
       if (!unitSessionParameters.isEmpty()) {
-        ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+          ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
         acsUnit.addOrChangeSessionUnitParameters(unitSessionParameters, profile);
       }
     } catch (SQLException sqle) {
@@ -138,6 +138,6 @@ public class DBAccessSessionTR069 {
             "\t" + pvs.getName() + " : does not exist, cannot write value " + pvs.getValue());
       }
     }
-    DBAccessStatic.queueUnitParameters(unit, unitParameters, profile);
+    unitParameters.forEach(unit::toWriteQueue);
   }
 }

--- a/tr069/src/main/java/com/github/freeacs/base/db/DBAccessStatic.java
+++ b/tr069/src/main/java/com/github/freeacs/base/db/DBAccessStatic.java
@@ -24,7 +24,6 @@ public class DBAccessStatic {
   }
 
   public static byte[] readFirmwareImage(File firmwareFresh) throws SQLException {
-    long start = System.currentTimeMillis();
     String action = "readFirmwareImage";
     try {
       File firmwareCache =
@@ -40,14 +39,13 @@ public class DBAccessStatic {
       }
       return firmwareReturn.getContent();
     } catch (Throwable t) {
-      DBAccess.handleError(action, t);
+      DBAccessErrorHandler.handleError(action, t);
     }
     return null; // Unreachable code - compiler doesn't detect it
   }
 
   public static void startUnitJob(String unitId, Integer jobId, DataSource xapsDataSource)
       throws SQLException {
-    long start = System.currentTimeMillis();
     String action = "startUnitJob";
     try {
       UnitJobs unitJobs = new UnitJobs(xapsDataSource);
@@ -61,14 +59,13 @@ public class DBAccessStatic {
             "The unit-job couldn't be started. The reason might it is already COMPLETED_OK state");
       }
     } catch (Throwable t) {
-      DBAccess.handleError(action, t);
+      DBAccessErrorHandler.handleError(action, t);
     }
   }
 
   public static void stopUnitJob(
       String unitId, Integer jobId, String unitJobStatus, DataSource xapsDataSource)
       throws SQLException {
-    long start = System.currentTimeMillis();
     String action = "stopUnitJob";
     try {
       UnitJobs unitJobs = new UnitJobs(xapsDataSource);
@@ -83,15 +80,8 @@ public class DBAccessStatic {
             "The unit-job couldn't be stopped. The reason might be it is deleted or maybe even in COMPLETED_OK state already");
       }
     } catch (Throwable t) {
-      DBAccess.handleError(action, t);
+      DBAccessErrorHandler.handleError(action, t);
     }
   }
 
-  /** Write to queue, will be written to DB at the end of TR-069-session. */
-  public static void queueUnitParameters(
-      Unit unit, List<UnitParameter> unitParameters, Profile profile) {
-    for (UnitParameter up : unitParameters) {
-      unit.toWriteQueue(up);
-    }
-  }
 }

--- a/tr069/src/main/java/com/github/freeacs/base/http/AuthenticatorUtil.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/AuthenticatorUtil.java
@@ -4,17 +4,17 @@ import com.github.freeacs.base.Log;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
-public class Util {
-  public static String getRealm() {
+class AuthenticatorUtil {
+  static String getRealm() {
     return "xaps";
   }
 
-  public static boolean startsWithIgnoreCase(String str, String prefix) {
+  private static boolean startsWithIgnoreCase(String str, String prefix) {
     String str_prefix = str.substring(0, prefix.length());
     return str_prefix.compareToIgnoreCase(prefix) == 0;
   }
 
-  public static String removePrefix(String str, String prefix) {
+  static String removePrefix(String str, String prefix) {
     if (startsWithIgnoreCase(str, prefix)) {
       return str.substring(prefix.length());
     } else {
@@ -22,7 +22,7 @@ public class Util {
     }
   }
 
-  public static String base64decode(String str) {
+  static String base64decode(String str) {
     byte[] data1 = str.getBytes();
     byte[] data2 = org.apache.commons.codec.binary.Base64.decodeBase64(data1);
     return new String(data2);
@@ -32,7 +32,7 @@ public class Util {
    * Removes the quotes on a string. RFC2617 states quotes are optional for all parameters except
    * realm.
    */
-  public static String removeQuotes(String quotedString, boolean quotesRequired) {
+  static String removeQuotes(String quotedString, boolean quotesRequired) {
     // support both quoted and non-quoted
     if (!quotedString.isEmpty() && quotedString.charAt(0) != '"' && !quotesRequired) {
       return quotedString;
@@ -44,7 +44,7 @@ public class Util {
   }
 
   /** Removes the quotes on a string. */
-  public static String removeQuotes(String quotedString) {
+  static String removeQuotes(String quotedString) {
     return removeQuotes(quotedString, false);
   }
 
@@ -52,7 +52,7 @@ public class Util {
    * Convert the authentication username to unitid (should be 1:1, but there might be some vendor
    * specific problems to solve...
    */
-  public static String username2unitId(String username) {
+  static String username2unitId(String username) {
     String unitId;
 
     // Fix for Thompson ST780
@@ -68,7 +68,7 @@ public class Util {
       unitId = URLDecoder.decode(unitId, "UTF-8");
     } catch (UnsupportedEncodingException uee) {
       Log.warn(
-          Util.class,
+          AuthenticatorUtil.class,
           "Not possible to decode username using UTF-8 - username may possibly be wrong",
           uee);
     }

--- a/tr069/src/main/java/com/github/freeacs/base/http/BasicAuthenticator.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/BasicAuthenticator.java
@@ -3,6 +3,7 @@ package com.github.freeacs.base.http;
 import com.github.freeacs.base.BaseCache;
 import com.github.freeacs.base.Log;
 import com.github.freeacs.base.NoDataAvailableException;
+import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.util.SystemParameters;
 import com.github.freeacs.http.HTTPRequestResponseData;
@@ -11,13 +12,13 @@ import com.github.freeacs.tr069.exception.TR069AuthenticationException;
 import java.sql.SQLException;
 import javax.servlet.http.HttpServletResponse;
 
-public class BasicAuthenticator {
+class BasicAuthenticator {
   private static void sendChallenge(HttpServletResponse res) {
     res.setHeader("WWW-Authenticate", "Basic realm=\"" + Util.getRealm() + "\"");
     res.setStatus(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
   }
 
-  public static boolean authenticate(
+  static boolean authenticate(
       HTTPRequestResponseData reqRes, boolean isDiscoveryMode, String[] discoveryBlocked)
       throws TR069AuthenticationException {
     String authorization = reqRes.getRawRequest().getHeader("authorization");
@@ -77,7 +78,7 @@ public class BasicAuthenticator {
     try {
       SessionData sessionData = reqRes.getSessionData();
       sessionData.setUnitId(unitId);
-      new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs()).updateParametersFromDB(sessionData, isDiscoveryMode); // Unit is now stored in sessionData
+      new DBAccessSession(DBAccess.getInstance().getDBI().getAcs()).updateParametersFromDB(sessionData, isDiscoveryMode); // Unit is now stored in sessionData
       String secret = null;
       if (sessionData.isFirstConnect() && isDiscoveryMode) {
         for (String blocked : discoveryBlocked) {

--- a/tr069/src/main/java/com/github/freeacs/base/http/BasicAuthenticator.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/BasicAuthenticator.java
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 
 class BasicAuthenticator {
   private static void sendChallenge(HttpServletResponse res) {
-    res.setHeader("WWW-Authenticate", "Basic realm=\"" + Util.getRealm() + "\"");
+    res.setHeader("WWW-Authenticate", "Basic realm=\"" + AuthenticatorUtil.getRealm() + "\"");
     res.setStatus(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
   }
 
@@ -50,9 +50,9 @@ class BasicAuthenticator {
         "Basic verification of CPE starts, located on IP-address "
             + reqRes.getRawRequest().getRemoteHost());
     authorization = authorization.trim();
-    authorization = Util.removePrefix(authorization, "basic");
+    authorization = AuthenticatorUtil.removePrefix(authorization, "basic");
     authorization = authorization.trim();
-    String userpass = Util.base64decode(authorization);
+    String userpass = AuthenticatorUtil.base64decode(authorization);
 
     // Validate any credentials already included with this request
     String username;
@@ -68,7 +68,7 @@ class BasicAuthenticator {
     }
 
     // Do database read parameters and then perform verification
-    String unitId = Util.username2unitId(username);
+    String unitId = AuthenticatorUtil.username2unitId(username);
     Log.debug(
         DigestAuthenticator.class,
         "Basic verification identifed unit id "

--- a/tr069/src/main/java/com/github/freeacs/base/http/DigestAuthenticator.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/DigestAuthenticator.java
@@ -3,6 +3,7 @@ package com.github.freeacs.base.http;
 import com.github.freeacs.base.BaseCache;
 import com.github.freeacs.base.Log;
 import com.github.freeacs.base.NoDataAvailableException;
+import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.util.SystemParameters;
 import com.github.freeacs.http.HTTPRequestResponseData;
@@ -12,7 +13,7 @@ import java.sql.SQLException;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.codec.digest.DigestUtils;
 
-public class DigestAuthenticator {
+class DigestAuthenticator {
   private static void sendChallenge(
       String remoteAddr, HttpServletResponse res, String digestSecret) {
     long now = System.currentTimeMillis();
@@ -20,7 +21,7 @@ public class DigestAuthenticator {
     res.setStatus(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
   }
 
-  public static boolean authenticate(
+  static boolean authenticate(
       HTTPRequestResponseData reqRes, boolean isDiscoveryMode, String digestSecret)
       throws TR069AuthenticationException {
     String authorization = reqRes.getRawRequest().getHeader("authorization");
@@ -57,15 +58,15 @@ public class DigestAuthenticator {
     res.setHeader("WWW-Authenticate", authenticateHeader);
   }
 
-  public static String passwordMd5(
-      String username,
-      String password,
-      String method,
-      String uri,
-      String nonce,
-      String nc,
-      String cnonce,
-      String qop) {
+  private static String passwordMd5(
+          String username,
+          String password,
+          String method,
+          String uri,
+          String nonce,
+          String nc,
+          String cnonce,
+          String qop) {
     String realm = Util.getRealm();
     String a1 = username + ":" + realm + ":" + password;
     String md5a1 = DigestUtils.md5Hex(a1);
@@ -173,7 +174,7 @@ public class DigestAuthenticator {
     try {
       SessionData sessionData = reqRes.getSessionData();
       sessionData.setUnitId(unitId);
-      new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs()).updateParametersFromDB(sessionData, isDiscoveryMode);
+      new DBAccessSession(DBAccess.getInstance().getDBI().getAcs()).updateParametersFromDB(sessionData, isDiscoveryMode);
       BaseCache.putSessionData(unitId, sessionData);
       String secret = sessionData.getAcsParameters().getValue(SystemParameters.SECRET);
       if (secret != null

--- a/tr069/src/main/java/com/github/freeacs/base/http/DigestAuthenticator.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/DigestAuthenticator.java
@@ -43,7 +43,7 @@ class DigestAuthenticator {
    * @param nonce nonce token
    */
   private static void setAuthenticateHeader(HttpServletResponse res, String nonce) {
-    String realm = Util.getRealm();
+    String realm = AuthenticatorUtil.getRealm();
 
     String authenticateHeader =
         "Digest realm=\""
@@ -67,7 +67,7 @@ class DigestAuthenticator {
           String nc,
           String cnonce,
           String qop) {
-    String realm = Util.getRealm();
+    String realm = AuthenticatorUtil.getRealm();
     String a1 = username + ":" + realm + ":" + password;
     String md5a1 = DigestUtils.md5Hex(a1);
     String a2 = method + ":" + uri;
@@ -90,7 +90,7 @@ class DigestAuthenticator {
         "Digest verification of CPE starts, located on IP-address "
             + reqRes.getRawRequest().getRemoteHost());
     authorization = authorization.trim();
-    authorization = Util.removePrefix(authorization, "digest");
+    authorization = AuthenticatorUtil.removePrefix(authorization, "digest");
     authorization = authorization.trim();
 
     String[] tokens = authorization.split(",(?=(?:[^\"]*\"[^\"]*\")+$)");
@@ -122,28 +122,28 @@ class DigestAuthenticator {
       String currentTokenName = currentToken.substring(0, equalSign).trim();
       String currentTokenValue = currentToken.substring(equalSign + 1).trim();
       if ("username".equals(currentTokenName)) {
-        username = Util.removeQuotes(currentTokenValue);
+        username = AuthenticatorUtil.removeQuotes(currentTokenValue);
       }
       if ("realm".equals(currentTokenName)) {
-        realm = Util.removeQuotes(currentTokenValue, true);
+        realm = AuthenticatorUtil.removeQuotes(currentTokenValue, true);
       }
       if ("nonce".equals(currentTokenName)) {
-        nonce = Util.removeQuotes(currentTokenValue);
+        nonce = AuthenticatorUtil.removeQuotes(currentTokenValue);
       }
       if ("nc".equals(currentTokenName)) {
-        nc = Util.removeQuotes(currentTokenValue);
+        nc = AuthenticatorUtil.removeQuotes(currentTokenValue);
       }
       if ("cnonce".equals(currentTokenName)) {
-        cnonce = Util.removeQuotes(currentTokenValue);
+        cnonce = AuthenticatorUtil.removeQuotes(currentTokenValue);
       }
       if ("qop".equals(currentTokenName)) {
-        qop = Util.removeQuotes(currentTokenValue);
+        qop = AuthenticatorUtil.removeQuotes(currentTokenValue);
       }
       if ("uri".equals(currentTokenName)) {
-        uri = Util.removeQuotes(currentTokenValue);
+        uri = AuthenticatorUtil.removeQuotes(currentTokenValue);
       }
       if ("response".equals(currentTokenName)) {
-        response = Util.removeQuotes(currentTokenValue);
+        response = AuthenticatorUtil.removeQuotes(currentTokenValue);
       }
     }
 
@@ -164,7 +164,7 @@ class DigestAuthenticator {
     }
 
     // Do database read parameters and then perform verification
-    String unitId = Util.username2unitId(username);
+    String unitId = AuthenticatorUtil.username2unitId(username);
     Log.debug(
         DigestAuthenticator.class,
         "Digest verification identifed unit id "

--- a/tr069/src/main/java/com/github/freeacs/base/http/FileServlet.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/FileServlet.java
@@ -20,8 +20,8 @@ public class FileServlet extends AbstractHttpDataWrapper {
 
   private final String context;
 
-  public FileServlet(DBAccess dbAccess, String context, Properties properties) {
-    super(dbAccess, properties);
+  public FileServlet(String context, Properties properties) {
+    super(properties);
     this.context = context;
   }
 
@@ -45,7 +45,7 @@ public class FileServlet extends AbstractHttpDataWrapper {
         }
       }
 
-      ACS acs = dbAccess.getDBI().getAcs();
+      ACS acs = DBAccess.getInstance().getDBI().getAcs();
       File firmware;
       String pathInfo = req.getPathInfo().substring(this.context.length());
       pathInfo = pathInfo.replaceAll("--", " ");

--- a/tr069/src/main/java/com/github/freeacs/base/http/OKServlet.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/OKServlet.java
@@ -8,29 +8,18 @@ import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class OKServlet {
   private static Map<String, Long> currentConnectionTmsMap = new HashMap<>();
 
-  private final DBAccess dbAccess;
-
-  public OKServlet(DBAccess dbAccess) {
-    this.dbAccess = dbAccess;
-  }
-
-  public void doPost(HttpServletRequest req, HttpServletResponse res) throws IOException {
-    doGet(req, res);
-  }
-
   @SuppressWarnings("rawtypes")
   public void doGet(HttpServletRequest req, HttpServletResponse res) throws IOException {
     PrintWriter out = res.getWriter();
     StringBuilder status = new StringBuilder("FREEACSOK");
     try {
-      DBI dbi = dbAccess.getDBI();
+      DBI dbi = DBAccess.getInstance().getDBI();
       if (dbi != null && dbi.getDbiThrowable() != null) {
         status =
             new StringBuilder("ERROR: DBI reported error:\n")

--- a/tr069/src/main/java/com/github/freeacs/base/http/ThreadCounter.java
+++ b/tr069/src/main/java/com/github/freeacs/base/http/ThreadCounter.java
@@ -24,9 +24,6 @@ public class ThreadCounter {
 
   /**
    * Returns false if a request has not been responded to, and a second request is "counted".
-   *
-   * @param sessionData
-   * @return
    */
   public static synchronized boolean isRequestAllowed(SessionDataI sessionData) {
     if (sessionData.getUnitId() != null) {
@@ -64,7 +61,7 @@ public class ThreadCounter {
     }
   }
 
-  public static synchronized Map<String, Long> cloneCurrentSessions() {
+  static synchronized Map<String, Long> cloneCurrentSessions() {
     Map<String, Long> currentSessionsClone = new HashMap<>();
     for (Entry<String, Long> entry : currentSessions.entrySet()) {
       currentSessionsClone.put(entry.getKey(), entry.getValue());
@@ -72,7 +69,7 @@ public class ThreadCounter {
     return currentSessionsClone;
   }
 
-  public static int currentSessionsCount() {
+  static int currentSessionsCount() {
     return currentSessions.size();
   }
 }

--- a/tr069/src/main/java/com/github/freeacs/http/AbstractHttpDataWrapper.java
+++ b/tr069/src/main/java/com/github/freeacs/http/AbstractHttpDataWrapper.java
@@ -1,23 +1,19 @@
 package com.github.freeacs.http;
 
-import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.tr069.Properties;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.sql.SQLException;
 
 public abstract class AbstractHttpDataWrapper {
-    protected final DBAccess dbAccess;
     protected final Properties properties;
 
-    public AbstractHttpDataWrapper(DBAccess dbAccess, Properties properties) {
-        this.dbAccess = dbAccess;
+    public AbstractHttpDataWrapper(Properties properties) {
         this.properties = properties;
     }
 
-    protected HTTPRequestResponseData getHttpRequestResponseData(HttpServletRequest req, HttpServletResponse res) throws SQLException {
-        HTTPRequestResponseData reqRes = new HTTPRequestResponseData(req, res, dbAccess);
+    protected HTTPRequestResponseData getHttpRequestResponseData(HttpServletRequest req, HttpServletResponse res) {
+        HTTPRequestResponseData reqRes = new HTTPRequestResponseData(req, res);
         reqRes.getRequestData().setContextPath(properties.getContextPath());
         return reqRes;
     }

--- a/tr069/src/main/java/com/github/freeacs/http/HTTPRequestResponseData.java
+++ b/tr069/src/main/java/com/github/freeacs/http/HTTPRequestResponseData.java
@@ -3,17 +3,14 @@ package com.github.freeacs.http;
 import com.github.freeacs.base.BaseCache;
 import com.github.freeacs.base.BaseCacheException;
 import com.github.freeacs.base.Log;
-import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.tr069.SessionData;
 import com.github.freeacs.tr069.xml.TR069TransactionID;
-import java.sql.SQLException;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 public class HTTPRequestResponseData {
-  private final DBAccess dbAccess;
 
   private HTTPRequestData requestData;
 
@@ -29,12 +26,11 @@ public class HTTPRequestResponseData {
 
   private SessionData sessionData;
 
-  protected HTTPRequestResponseData(HttpServletRequest rawRequest, HttpServletResponse rawResponse, DBAccess dbAccess) {
+  protected HTTPRequestResponseData(HttpServletRequest rawRequest, HttpServletResponse rawResponse) {
     this.rawRequest = rawRequest;
     this.rawResponse = rawResponse;
     this.requestData = new HTTPRequestData();
     this.responseData = new HTTPResponseData();
-    this.dbAccess = dbAccess;
 
     String sessionId = rawRequest.getSession().getId();
     try {
@@ -100,10 +96,6 @@ public class HTTPRequestResponseData {
 
   public SessionData getSessionData() {
     return sessionData;
-  }
-
-  public DBAccess getDbAccess() {
-    return dbAccess;
   }
 
   public String getRealIPAddress() {

--- a/tr069/src/main/java/com/github/freeacs/tr069/ParameterKey.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/ParameterKey.java
@@ -35,7 +35,7 @@ public class ParameterKey {
     Map<String, ParameterValueStruct> fromDB = sessionData.getFromDB();
     String jobId = sessionData.getAcsParameters().getValue(SystemParameters.JOB_CURRENT);
     if (jobId != null && !"".equals(jobId.trim())) {
-        Job job = sessionData.getUnittype().getJobs().getById(Integer.valueOf(jobId));
+      Job job = sessionData.getUnittype().getJobs().getById(Integer.valueOf(jobId));
       if (job != null) {
         Log.debug(
             ParameterKey.class,

--- a/tr069/src/main/java/com/github/freeacs/tr069/ParameterKey.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/ParameterKey.java
@@ -1,7 +1,6 @@
 package com.github.freeacs.tr069;
 
 import com.github.freeacs.base.Log;
-import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.dbi.Job;
 import com.github.freeacs.dbi.JobParameter;
 import com.github.freeacs.dbi.UnittypeParameter;
@@ -36,7 +35,7 @@ public class ParameterKey {
     Map<String, ParameterValueStruct> fromDB = sessionData.getFromDB();
     String jobId = sessionData.getAcsParameters().getValue(SystemParameters.JOB_CURRENT);
     if (jobId != null && !"".equals(jobId.trim())) {
-      Job job = DBAccess.getJob(sessionData, jobId);
+        Job job = sessionData.getUnittype().getJobs().getById(Integer.valueOf(jobId));
       if (job != null) {
         Log.debug(
             ParameterKey.class,

--- a/tr069/src/main/java/com/github/freeacs/tr069/Provisioning.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/Provisioning.java
@@ -228,7 +228,7 @@ public class Provisioning extends AbstractHttpDataWrapper {
       Unit unit = reqRes.getSessionData().getUnit();
       if (unit != null) {
         ACS acs = DBAccess.getInstance().getDBI().getAcs();
-          ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
+        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
         acsUnit.addOrChangeQueuedUnitParameters(unit);
       }
     } catch (Throwable t) {

--- a/tr069/src/main/java/com/github/freeacs/tr069/Provisioning.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/Provisioning.java
@@ -38,21 +38,17 @@ import javax.servlet.http.HttpServletResponse;
 public class Provisioning extends AbstractHttpDataWrapper {
   private static ScriptExecutions executions;
 
-
   private final ExecutorWrapper executorWrapper;
 
-  public Provisioning(
-      DBAccess dbAccess,
-      Properties properties,
-      ExecutorWrapper executorWrapper) {
-    super(dbAccess, properties);
+  public Provisioning(Properties properties, ExecutorWrapper executorWrapper) {
+    super(properties);
     this.executorWrapper = executorWrapper;
   }
 
   public void init() {
     Log.notice(Provisioning.class, "Server starts...");
     try {
-      DBI dbi = dbAccess.getDBI();
+      DBI dbi = DBAccess.getInstance().getDBI();
       scheduleMessageListenerTask(dbi);
       scheduleKickTask(dbi);
       scheduleActiveDeviceDetectionTask(dbi);
@@ -60,7 +56,7 @@ public class Provisioning extends AbstractHttpDataWrapper {
       Log.fatal(Provisioning.class, "Couldn't start BackgroundProcesses correctly ", t);
     }
     try {
-      executions = new ScriptExecutions(dbAccess.getMainDataSource());
+      executions = new ScriptExecutions(DBAccess.getInstance().getDataSource());
     } catch (Throwable t) {
       Log.fatal(
           Provisioning.class,
@@ -231,8 +227,8 @@ public class Provisioning extends AbstractHttpDataWrapper {
     try {
       Unit unit = reqRes.getSessionData().getUnit();
       if (unit != null) {
-        ACS acs = reqRes.getDbAccess().getDBI().getAcs();
-        ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+        ACS acs = DBAccess.getInstance().getDBI().getAcs();
+          ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
         acsUnit.addOrChangeQueuedUnitParameters(unit);
       }
     } catch (Throwable t) {

--- a/tr069/src/main/java/com/github/freeacs/tr069/background/ScheduledKickTask.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/background/ScheduledKickTask.java
@@ -1,6 +1,5 @@
 package com.github.freeacs.tr069.background;
 
-import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.common.scheduler.TaskDefaultImpl;
 import com.github.freeacs.dbi.ACS;
 import com.github.freeacs.dbi.ACSUnit;
@@ -83,7 +82,7 @@ public class ScheduledKickTask extends TaskDefaultImpl {
           continue;
         }
         Unit unit = uk.getUnit();
-        ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+        ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
         acsUnit.addOrChangeQueuedUnitParameters(unit);
         dbi.publishKick(unit, SyslogConstants.FACILITY_STUN);
         uk.setNextTms(now + 30000);

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/EmptyDecisionStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/EmptyDecisionStrategy.java
@@ -128,8 +128,8 @@ public class EmptyDecisionStrategy implements DecisionStrategy {
         sessionData.setToDB(toDB);
         DBAccessSessionTR069.writeUnitParams(sessionData); // queue-parameters - will be written at end-of-session
         if (!queue) { // execute changes immediately - since otherwise these parameters will be lost (in the event of GPNRes.process())
-            ACS acs = reqRes.getDbAccess().getDBI().getAcs();
-            ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+            ACS acs = DBAccess.getInstance().getDBI().getAcs();
+            ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
             acsUnit.addOrChangeQueuedUnitParameters(sessionData.getUnit());
         }
         sessionData.setToDB(null);

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/GetParameterValues/ShellJobLogic.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/GetParameterValues/ShellJobLogic.java
@@ -2,7 +2,6 @@ package com.github.freeacs.tr069.methods.decision.GetParameterValues;
 
 import com.github.freeacs.base.Log;
 import com.github.freeacs.base.UnitJob;
-import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSessionTR069;
 import com.github.freeacs.common.util.Cache;
 import com.github.freeacs.common.util.CacheValue;
@@ -121,7 +120,7 @@ public class ShellJobLogic {
         UnittypeParameters utps = sessionData.getUnittype().getUnittypeParameters();
         Unit unit;
         try {
-            ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+            ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
             unit = acsUnit.getUnitById(sessionData.getUnitId());
         } catch (SQLException e) {
             throw new TR069DatabaseException(e);
@@ -176,7 +175,7 @@ public class ShellJobLogic {
         }
         if (unitParameters.size() > 0) {
             try {
-                ACSUnit acsUnit = DBAccess.getXAPSUnit(acs);
+                ACSUnit acsUnit = new ACSUnit(acs.getDataSource(), acs, acs.getSyslog());
                 acsUnit.addOrChangeUnitParameters(unitParameters, sessionData.getProfile());
             } catch (SQLException sqle) {
                 throw new TR069DatabaseException(sqle);

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/GetParameterValuesDecisionStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/GetParameterValuesDecisionStrategy.java
@@ -2,6 +2,7 @@ package com.github.freeacs.tr069.methods.decision;
 
 import com.github.freeacs.base.*;
 import com.github.freeacs.base.UnitJob;
+import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.base.db.DBAccessSessionTR069;
 import com.github.freeacs.dbi.*;
@@ -92,7 +93,7 @@ public class GetParameterValuesDecisionStrategy implements DecisionStrategy {
             sessionData.getProvisioningMessage().setProvOutput(ProvisioningMessage.ProvOutput.RESET);
             serviceWindow = new ServiceWindow(sessionData, true);
             if (serviceWindow.isWithin()) {
-                Util.resetReset(sessionData);
+                ResetUtil.resetReset(sessionData);
                 reqRes.getResponseData().setMethod(ProvisioningMethod.FactoryReset.name());
                 return;
             } else {
@@ -102,7 +103,7 @@ public class GetParameterValuesDecisionStrategy implements DecisionStrategy {
             sessionData.getProvisioningMessage().setProvOutput(ProvisioningMessage.ProvOutput.REBOOT);
             serviceWindow = new ServiceWindow(sessionData, true);
             if (serviceWindow.isWithin()) {
-                Util.resetReboot(sessionData);
+                ResetUtil.resetReboot(sessionData);
                 reqRes.getResponseData().setMethod(ProvisioningMethod.Reboot.name());
                 return;
             } else {
@@ -148,7 +149,7 @@ public class GetParameterValuesDecisionStrategy implements DecisionStrategy {
             // group-matching in job-search
             // will not affect the comparison in populateToCollections()
             updateUnitParameters(sessionData);
-            uj = JobLogic.checkNewJob(sessionData, reqRes.getDbAccess().getDBI().getAcs(), concurrentDownloadLimit); // may find a new job
+            uj = JobLogic.checkNewJob(sessionData, DBAccess.getInstance().getDBI().getAcs(), concurrentDownloadLimit); // may find a new job
         }
         Job job = sessionData.getJob();
         if (job != null) { // No job is present - process according to
@@ -187,7 +188,7 @@ public class GetParameterValuesDecisionStrategy implements DecisionStrategy {
         } else {
             if (type == JobFlag.JobType.SHELL) {
                 sessionData.getProvisioningMessage().setProvOutput(ProvisioningMessage.ProvOutput.SHELL);
-                ShellJobLogic.execute(sessionData, reqRes.getDbAccess().getDBI().getAcs(), job, uj, isDiscoveryMode);
+                ShellJobLogic.execute(sessionData, DBAccess.getInstance().getDBI().getAcs(), job, uj, isDiscoveryMode);
             } else { // type == JobType.CONFIG
                 // The service-window is unimportant for next PII calculation, will
                 // be set to 31 no matter what, since a job is "in the process".
@@ -622,9 +623,8 @@ public class GetParameterValuesDecisionStrategy implements DecisionStrategy {
         }
         sessionData.setToDB(toDB);
         try {
-            DBAccessSessionTR069 dbAccessSessionTR069 =
-                    new DBAccessSessionTR069(
-                            reqRes.getDbAccess().getDBI().getAcs(), new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs()));
+            ACS acs = DBAccess.getInstance().getDBI().getAcs();
+            DBAccessSessionTR069 dbAccessSessionTR069 = new DBAccessSessionTR069(acs, new DBAccessSession(acs));
             dbAccessSessionTR069.writeUnitSessionParams(sessionData);
             Log.debug(GetParameterValuesDecisionStrategy.class, toDB.size() + " params written to ACS session storage");
             reqRes.getResponseData().setMethod(ProvisioningMethod.Empty.name());

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/SetParameterValuesDecisionStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/decision/SetParameterValuesDecisionStrategy.java
@@ -2,6 +2,7 @@ package com.github.freeacs.tr069.methods.decision;
 
 import com.github.freeacs.base.Log;
 import com.github.freeacs.base.UnitJob;
+import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.dbi.UnitJobStatus;
 import com.github.freeacs.dbi.util.ProvisioningMode;
 import com.github.freeacs.http.HTTPRequestResponseData;
@@ -26,7 +27,7 @@ public class SetParameterValuesDecisionStrategy implements DecisionStrategy {
             Log.debug(
                     SetParameterValuesDecisionStrategy.class,
                     "UnitJob is COMPLETED without verification stage, since CPE does not support ParameterKey");
-            UnitJob uj = new UnitJob(sessionData, reqRes.getDbAccess().getDBI().getAcs(), sessionData.getJob(), false);
+            UnitJob uj = new UnitJob(sessionData, DBAccess.getInstance().getDBI().getAcs(), sessionData.getJob(), false);
             uj.stop(UnitJobStatus.COMPLETED_OK, properties.isDiscoveryMode());
         }
         reqRes.getResponseData().setMethod(ProvisioningMethod.Empty.name());

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/request/GetParameterNamesProcessStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/request/GetParameterNamesProcessStrategy.java
@@ -1,6 +1,7 @@
 package com.github.freeacs.tr069.methods.request;
 
 import com.github.freeacs.base.Log;
+import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.Unittype;
 import com.github.freeacs.dbi.UnittypeParameter;
@@ -25,7 +26,7 @@ public class GetParameterNamesProcessStrategy implements RequestProcessStrategy 
 
     private Properties properties;
 
-    public GetParameterNamesProcessStrategy(Properties properties) {
+    GetParameterNamesProcessStrategy(Properties properties) {
         this.properties = properties;
     }
 
@@ -79,7 +80,7 @@ public class GetParameterNamesProcessStrategy implements RequestProcessStrategy 
                                     + " was found more than once in the GPNRes");
                 }
             }
-            DBAccessSession dbAccessSession = new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs());
+            DBAccessSession dbAccessSession = new DBAccessSession(DBAccess.getInstance().getDBI().getAcs());
             dbAccessSession.writeUnittypeParameters(sessionData, utpList);
             Log.debug(
                     GetParameterNamesProcessStrategy.class,

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/request/InformRequestProcessStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/request/InformRequestProcessStrategy.java
@@ -3,6 +3,7 @@ package com.github.freeacs.tr069.methods.request;
 import com.github.freeacs.base.BaseCache;
 import com.github.freeacs.base.JobLogic;
 import com.github.freeacs.base.Log;
+import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.base.db.DBAccessSessionTR069;
 import com.github.freeacs.dbi.Unit;
@@ -30,7 +31,7 @@ import java.util.TreeSet;
 public class InformRequestProcessStrategy implements RequestProcessStrategy {
     private Properties properties;
 
-    public InformRequestProcessStrategy(Properties properties) {
+    InformRequestProcessStrategy(Properties properties) {
         this.properties = properties;
     }
 
@@ -55,12 +56,12 @@ public class InformRequestProcessStrategy implements RequestProcessStrategy {
             sessionData.setSerialNumber(deviceIdStruct.getSerialNumber());
             parseEvents(parser, sessionData);
             parseParameters(sessionData, parser);
-            DBAccessSession dbAccessSession = new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs());
+            DBAccessSession dbAccessSession = new DBAccessSession(DBAccess.getInstance().getDBI().getAcs());
             dbAccessSession.updateParametersFromDB(sessionData, isDiscoveryMode); // Unit-object is read and populated in SessionData
             logPeriodicInformTiming(sessionData);
             ScheduledKickTask.removeUnit(unitId);
             if (isDiscoveryMode && sessionData.isFirstConnect()) {
-                DBAccessSessionTR069 dbAccessSessionTR069 = new DBAccessSessionTR069(reqRes.getDbAccess().getDBI().getAcs(), dbAccessSession);
+                DBAccessSessionTR069 dbAccessSessionTR069 = new DBAccessSessionTR069(DBAccess.getInstance().getDBI().getAcs(), dbAccessSession);
 
                 String unitTypeName = deviceIdStruct.getProductClass();
 
@@ -83,7 +84,7 @@ public class InformRequestProcessStrategy implements RequestProcessStrategy {
             }
             sessionData.getCommandKey().setServerKey(reqRes);
             sessionData.getParameterKey().setServerKey(reqRes);
-            boolean jobOk = JobLogic.checkJobOK(sessionData, reqRes.getDbAccess().getDBI().getAcs(), isDiscoveryMode);
+            boolean jobOk = JobLogic.checkJobOK(sessionData, DBAccess.getInstance().getDBI().getAcs(), isDiscoveryMode);
             sessionData.setJobUnderExecution(!jobOk);
         } catch (SQLException e) {
             throw new TR069DatabaseException(e);

--- a/tr069/src/main/java/com/github/freeacs/tr069/methods/request/SetParameterValuesRequestProcessStrategy.java
+++ b/tr069/src/main/java/com/github/freeacs/tr069/methods/request/SetParameterValuesRequestProcessStrategy.java
@@ -1,6 +1,7 @@
 package com.github.freeacs.tr069.methods.request;
 
 import com.github.freeacs.base.Log;
+import com.github.freeacs.base.db.DBAccess;
 import com.github.freeacs.base.db.DBAccessSession;
 import com.github.freeacs.dbi.SyslogConstants;
 import com.github.freeacs.dbi.util.SyslogClient;
@@ -26,7 +27,7 @@ public class SetParameterValuesRequestProcessStrategy implements RequestProcessS
         ParameterList paramList = sessionData.getToCPE();
         for (ParameterValueStruct pvs : paramList.getParameterValueList()) {
             Log.notice(SetParameterValuesRequestProcessStrategy.class, "\t" + pvs.getName() + " : " + pvs.getValue());
-            String user = new DBAccessSession(reqRes.getDbAccess().getDBI().getAcs())
+            String user = new DBAccessSession(DBAccess.getInstance().getDBI().getAcs())
                             .getAcs()
                             .getSyslog()
                             .getIdentity()

--- a/tr069/src/test/java/com/github/freeacs/http/AbstractHttpDataWrapperTest.java
+++ b/tr069/src/test/java/com/github/freeacs/http/AbstractHttpDataWrapperTest.java
@@ -52,7 +52,7 @@ public class AbstractHttpDataWrapperTest {
         final Properties properties = new Properties(ConfigFactory.load());
 
         // When:
-        final AbstractHttpDataWrapper wrapper = new AbstractHttpDataWrapper(mockDBAccess, properties) {};
+        final AbstractHttpDataWrapper wrapper = new AbstractHttpDataWrapper(properties) {};
         final HTTPRequestResponseData httpRequestResponseData =
             wrapper.getHttpRequestResponseData(mockServletRequest, mockServletResponse);
 


### PR DESCRIPTION
The DBI object should in a normal spring app be autowired. Since we are currently using Spark, this object must be made a static singleton. However by doing this we make it easier to port the application to Spring Boot at a later time, because what we will do then is to convert classes that use this singleton directly to `@Component` or `@Service`, or convert the parents and pass the DBI object down. The good thing now is that we no longer have any DBI object stored in SessionData object or HttpRequestResponseData class. Or anywhere else. It is always accessed statically.